### PR TITLE
Fix uncaught error "Cannot read properties of undefined (reading '_setAuthenticating')"

### DIFF
--- a/modules/WebSocket.js
+++ b/modules/WebSocket.js
@@ -227,7 +227,7 @@
             cmd = Commands.format(Commands.AUTHENTICATE, hash);
         }
 
-        this.send(cmd, EncryptionType.NONE).then(this._handleSuccessFullAuth, this._handleBadAuthResponse);
+        this.send(cmd, EncryptionType.NONE).then(this._handleSuccessFullAuth.bind(this), this._handleBadAuthResponse.bind(this));
     };
 
     WebSocket.prototype._handleSuccessFullAuth = function _handleSuccessFullAuth() {
@@ -307,7 +307,7 @@
             } else {
                 throw new Error("Could not acquire token!");
             }
-        }.bind(this), this._handleBadAuthResponse);
+        }.bind(this), this._handleBadAuthResponse.bind(this));
     };
 
     /**


### PR DESCRIPTION
TypeError: Cannot read properties of undefined (reading '_setAuthenticating')
    at _handleBadAuthResponse (C:\Workspace\personal\loxone-gateway\node_modules\lxcommunicator\modules\WebSocket.js:343:14)
    at _rejected (C:\Workspace\personal\loxone-gateway\node_modules\q\q.js:864:24)
    at C:\Workspace\personal\loxone-gateway\node_modules\q\q.js:890:30
    at Promise.when (C:\Workspace\personal\loxone-gateway\node_modules\q\q.js:1142:31)
    at Promise.promise.promiseDispatch (C:\Workspace\personal\loxone-gateway\node_modules\q\q.js:808:41)
    at C:\Workspace\personal\loxone-gateway\node_modules\q\q.js:624:44
    at runSingle (C:\Workspace\personal\loxone-gateway\node_modules\q\q.js:137:13)
    at flush (C:\Workspace\personal\loxone-gateway\node_modules\q\q.js:125:13)
    at processTicksAndRejections (node:internal/process/task_queues:78:11)

Also fixed another location where this was not bound to the function.